### PR TITLE
Termin hinzufügen

### DIFF
--- a/lib/model/Reminder.dart
+++ b/lib/model/Reminder.dart
@@ -1,0 +1,9 @@
+class Reminder{
+  final String title;
+  final DateTime date;
+
+  Reminder({
+    required this.title,
+    required this.date,
+  });
+}

--- a/lib/screen/HomeScreen.dart
+++ b/lib/screen/HomeScreen.dart
@@ -24,19 +24,44 @@ class _HomeScreen extends State<HomeScreen> {
         backgroundColor: Colors.black,
       ),
       floatingActionButton: FloatingActionButton(
+        backgroundColor: Colors.white,
         onPressed: () async {
           final Reminder? newReminder = await Navigator.push(context,
-              MaterialPageRoute(builder: (_) => NewReminderScreen())
+              MaterialPageRoute(builder: (_) => const NewReminderScreen())
           );
           setState(() {
             newReminder != null ? _reminderList.add(newReminder) : null;
           });
         },
+        child: const Icon(Icons.add),
       ),
       body: ListView.builder(
         itemCount: _reminderList.length,
         itemBuilder: (context, i) =>
-          ReminderTile(reminder: _reminderList[i])
+          ReminderTile(
+            reminder: _reminderList[i],
+            onLongPress: () => showDialog(
+                context: context,
+                builder: (_) => AlertDialog(
+                  title: const Text("Termin wird gelöscht?"),
+                  actions: [
+                    TextButton(
+                        onPressed: () => Navigator.pop(context),
+                        child: const Text("Abbrechen")
+                    ),
+                    TextButton(
+                        onPressed: () {
+                          setState(() {
+                            _reminderList.removeAt(i);
+                          });
+                          Navigator.pop(context);
+                        },
+                        child: const Text("OK")
+                    ),
+                  ],
+                )
+            )
+          )
       ),
     );
   }

--- a/lib/screen/HomeScreen.dart
+++ b/lib/screen/HomeScreen.dart
@@ -1,4 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:mobile_application_3/screen/NewReminderScreen.dart';
+import 'package:mobile_application_3/widget/ReminderTile.dart';
+
+import '../model/Reminder.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -9,6 +13,8 @@ class HomeScreen extends StatefulWidget {
 
 class _HomeScreen extends State<HomeScreen> {
 
+  final _reminderList = <Reminder>[];
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -16,6 +22,21 @@ class _HomeScreen extends State<HomeScreen> {
       appBar: AppBar(
         title: const Text("Mobile Application 3"),
         backgroundColor: Colors.black,
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          final Reminder? newReminder = await Navigator.push(context,
+              MaterialPageRoute(builder: (_) => NewReminderScreen())
+          );
+          setState(() {
+            newReminder != null ? _reminderList.add(newReminder) : null;
+          });
+        },
+      ),
+      body: ListView.builder(
+        itemCount: _reminderList.length,
+        itemBuilder: (context, i) =>
+          ReminderTile(reminder: _reminderList[i])
       ),
     );
   }

--- a/lib/screen/NewReminderScreen.dart
+++ b/lib/screen/NewReminderScreen.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_datetime_picker/flutter_datetime_picker.dart';
+import 'package:mobile_application_3/util/DateTimeUtil.dart';
 
 import '../model/Reminder.dart';
 
@@ -26,23 +28,56 @@ class _NewReminderScreen extends State<NewReminderScreen> {
         mainAxisSize: MainAxisSize.min,
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          TextField(
-            onChanged: (_) => setState(() {}),
-            controller: _nameController,
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 50),
+            child: TextField(
+              maxLength: 25,
+              decoration: const InputDecoration(
+                  hintText: "Termin-Name"
+              ),
+              onChanged: (_) => setState(() {}),
+              controller: _nameController,
+            ),
           ),
-          TextButton(
-            onPressed: () async {
-              final date = await showDatePicker(
-                  context: context,
-                  initialDate: DateTime.now(),
-                  firstDate: DateTime.now(),
-                  lastDate: DateTime(2100)
-              );
-              setState(() {
-                date != null ? _date = date : null;
-              });
-            },
-            child: const Text("Datum auswählen")
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Spacer(),
+              IconButton(
+                onPressed: () async {
+                  final dateTime = await DatePicker.showDateTimePicker(context,
+                      locale: LocaleType.de,
+                      currentTime: DateTime.now(),
+                      theme: const DatePickerTheme(
+                        backgroundColor: Colors.black,
+                        doneStyle: TextStyle(
+                            color: Colors.white
+                        ),
+                        cancelStyle: TextStyle(
+                            color: Colors.white
+                        ),
+                        itemStyle: TextStyle(
+                            color: Colors.white
+                        ),
+                      )
+                  );
+                  if (dateTime == null || dateTime.isBefore(DateTime.now())) {
+                    _date = null;
+                    const alert = SnackBar(content: Text("Der Termin liegt in der Vergangenheit!"));
+                    Future.delayed(Duration.zero).then((_) => ScaffoldMessenger.of(context).showSnackBar(alert));
+                  }
+                  setState(() {
+                    dateTime != null && dateTime.isAfter(DateTime.now()) ? _date = dateTime : null;
+                  });
+                },
+                icon: const Icon(Icons.edit_calendar),
+              ),
+              const Spacer(),
+              SizedBox(
+                child: _date != null ? Text(_date!.toReadable()) : const Text("Noch kein Datum festgelegt."),
+              ),
+              const Spacer()
+            ],
           ),
           const Spacer(),
           TextButton(

--- a/lib/screen/NewReminderScreen.dart
+++ b/lib/screen/NewReminderScreen.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+import '../model/Reminder.dart';
+
+class NewReminderScreen extends StatefulWidget{
+  const NewReminderScreen({super.key});
+
+  @override
+  State<StatefulWidget> createState() => _NewReminderScreen();
+}
+
+class _NewReminderScreen extends State<NewReminderScreen> {
+
+  final _nameController = TextEditingController();
+  DateTime? _date;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      appBar: AppBar(
+        title: const Text("Neuen Termin hinzufügen"),
+        backgroundColor: Colors.black,
+      ),
+      body: Column(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          TextField(
+            onChanged: (_) => setState(() {}),
+            controller: _nameController,
+          ),
+          TextButton(
+            onPressed: () async {
+              final date = await showDatePicker(
+                  context: context,
+                  initialDate: DateTime.now(),
+                  firstDate: DateTime.now(),
+                  lastDate: DateTime(2100)
+              );
+              setState(() {
+                date != null ? _date = date : null;
+              });
+            },
+            child: const Text("Datum auswählen")
+          ),
+          const Spacer(),
+          TextButton(
+            onPressed: _areFieldsEmpty() ? null : () {
+              final reminder = Reminder(
+                  title: _nameController.text.trim(),
+                  date: _date!
+              );
+              Navigator.pop(context, reminder);
+            },
+            child: const Text("Speichern")
+          ),
+          const Divider(height: 30, color: Colors.transparent)
+        ],
+      ),
+    );
+  }
+  
+  bool _areFieldsEmpty() => _nameController.text.trim().isEmpty || _date == null;
+}

--- a/lib/screen/ReminderScreen.dart
+++ b/lib/screen/ReminderScreen.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+import '../model/Reminder.dart';
+
+class ReminderScreen extends StatefulWidget{
+  const ReminderScreen({super.key, required this.reminder});
+
+  final Reminder reminder;
+
+  @override
+  State<StatefulWidget> createState() => _ReminderScreen();
+}
+
+class _ReminderScreen extends State<ReminderScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      appBar: AppBar(
+        title: Text(widget.reminder.title),
+        backgroundColor: Colors.black,
+      ),
+      body: Center(
+        child: Text(widget.reminder.date.toIso8601String()),
+      ),
+    );
+  }
+}

--- a/lib/screen/ReminderScreen.dart
+++ b/lib/screen/ReminderScreen.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:mobile_application_3/util/DateTimeUtil.dart';
+import 'package:mobile_application_3/util/CountDownUtil.dart';
 
 import '../model/Reminder.dart';
 
@@ -21,8 +23,14 @@ class _ReminderScreen extends State<ReminderScreen> {
         backgroundColor: Colors.black,
       ),
       body: Center(
-        child: Text(widget.reminder.date.toIso8601String()),
-      ),
+        child: Column(
+          children: [
+            const Divider(height: 20, color: Colors.transparent),
+            Text(widget.reminder.date.toReadable()),
+            CountDownUtil.inGerman(widget.reminder.date),
+          ],
+        ),
+      )
     );
   }
 }

--- a/lib/util/CountDownUtil.dart
+++ b/lib/util/CountDownUtil.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_countdown_timer/flutter_countdown_timer.dart';
+import 'package:mobile_application_3/util/DateTimeUtil.dart';
+
+class CountDownUtil{
+  static CountdownTimer inGerman(DateTime date){
+    return CountdownTimer(
+      endTime: date.getRemainingMilliSeconds(),
+      widgetBuilder: (BuildContext context, time) {
+        if (time == null) {
+          return const Center(
+            child: Text("Der Countdown ist abgelaufen!"),
+          );
+        }
+        String value = '';
+        if (time.days != null) {
+          var days = time.days!;
+          value = '$value$days Tag(e) und ';
+        }
+        var hours = (time.hours ?? 0).getNumberAddZero();
+        value = '$value$hours:';
+        var min = (time.min ?? 0).getNumberAddZero();
+        value = '$value$min:';
+        var sec = (time.sec ?? 0).getNumberAddZero();
+        value = '$value$sec verbleibend!';
+        return Text(
+          value,
+          style: const TextStyle(
+              fontWeight: FontWeight.bold,
+              fontSize: 15
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/util/DateTimeUtil.dart
+++ b/lib/util/DateTimeUtil.dart
@@ -1,0 +1,18 @@
+extension DT on DateTime {
+  String toReadable(){
+    return "am $day.$month.$year, um $hour:$minute Uhr";
+  }
+
+  int getRemainingMilliSeconds() {
+    return millisecondsSinceEpoch;
+  }
+}
+
+extension AddZero on int {
+  String getNumberAddZero() {
+    if (this < 10) {
+      return "0$this";
+    }
+    return toString();
+  }
+}

--- a/lib/widget/ReminderTile.dart
+++ b/lib/widget/ReminderTile.dart
@@ -4,9 +4,13 @@ import '../model/Reminder.dart';
 import '../screen/ReminderScreen.dart';
 
 class ReminderTile extends StatelessWidget{
-  const ReminderTile({super.key, required this.reminder});
+  const ReminderTile({super.key,
+    required this.reminder,
+    required this.onLongPress,
+  });
 
   final Reminder reminder;
+  final void Function()? onLongPress;
 
   @override
   Widget build(BuildContext context) {
@@ -14,6 +18,7 @@ class ReminderTile extends StatelessWidget{
       onTap: () => Navigator.push(context,
           MaterialPageRoute(builder: (_) => ReminderScreen(reminder: reminder))
       ),
+      onLongPress: onLongPress,
       child: SizedBox(
         height: MediaQuery.of(context).size.height/10,
         child: Card(

--- a/lib/widget/ReminderTile.dart
+++ b/lib/widget/ReminderTile.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+import '../model/Reminder.dart';
+import '../screen/ReminderScreen.dart';
+
+class ReminderTile extends StatelessWidget{
+  const ReminderTile({super.key, required this.reminder});
+
+  final Reminder reminder;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: () => Navigator.push(context,
+          MaterialPageRoute(builder: (_) => ReminderScreen(reminder: reminder))
+      ),
+      child: SizedBox(
+        height: MediaQuery.of(context).size.height/10,
+        child: Card(
+          child: Center(
+            child: Text(reminder.title),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -69,6 +69,20 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_countdown_timer:
+    dependency: "direct main"
+    description:
+      name: flutter_countdown_timer
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.1.0"
+  flutter_datetime_picker:
+    dependency: "direct main"
+    description:
+      name: flutter_datetime_picker
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.5.1"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,8 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   shared_preferences: ^2.0.17
+  flutter_datetime_picker: ^1.5.1
+  flutter_countdown_timer: ^4.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Erste Implementation für die Funktion einen Termin hinzuzufügen.

Aktuell noch _in-memory_. 

Persistente Speicherung muss noch mithilfe von _Shared Preferences_ erfolgen.

Data-Klasse für eine Erinnerung erstellt, sowie ein Widget, um es auf dem HomeScreen anzuzeigen und einem eigenen Screen, welcher weitere Details enthält, sobald auf das Widget _onTap_ ausgeführt wird.